### PR TITLE
Send metric value as float instead of string

### DIFF
--- a/etc/sensu/handlers/metrics/sensu-metrics.rb
+++ b/etc/sensu/handlers/metrics/sensu-metrics.rb
@@ -33,7 +33,7 @@ class SensuToInfluxDB < Sensu::Handler
       key.gsub!('.', '_')
       value = m[1].to_f
       #puts "Value: #{value}"
-      mydata = {:host => @event['client']['name'], :value => "#{value}",
+      mydata = {:host => @event['client']['name'], :value => value,
                 :ip => @event['client']['address']
                } 
       influxdb_data.write_point(key, mydata)


### PR DESCRIPTION
InfluxDB needs the metric value as a float64 or int64 not a string. Without this change InfluxDB is unable to perform functions like mean and median on the stored values.
